### PR TITLE
Configure CMS to use Netlify Identity with Git Gateway

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,15 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-// You can delete this file if you're not using it
+export const onClientEntry = () => {
+  // Redirect users after Netlify Identity authentication
+  if (window.netlifyIdentity) {
+    window.netlifyIdentity.on('init', user => {
+      if (!user) {
+        window.netlifyIdentity.on('login', () => {
+          document.location.href = '/admin/'
+        })
+      }
+    })
+  }
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,4 +4,13 @@
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
 
-// You can delete this file if you're not using it
+import React from 'react'
+
+export const onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <script
+      key="netlify-identity-widget"
+      src="https://identity.netlify.com/v1/netlify-identity-widget.js"
+    />,
+  ])
+}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,9 +1,6 @@
 backend:
-  name: github
-  repo: edhedges/edhedges.github.io
-  branch: master
-  base_url: https://api.netlify.com
-  auth_endpoint: auth
+  name: git-gateway
+  branch: dev
 
 # Uncomment for local development
 # local_backend: true

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex" />
   <title>Content Manager</title>
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->


### PR DESCRIPTION
Update CMS authentication to use Git Gateway with Netlify Identity:
- Change backend from GitHub OAuth to git-gateway in config.yml
- Update branch from master to dev to match current workflow
- Add Netlify Identity widget script to admin index.html
- Inject Identity widget into all pages via gatsby-ssr.js
- Add automatic redirect after login in gatsby-browser.js

This enables mobile publishing through Netlify Identity while keeping Cloudflare Pages for hosting.